### PR TITLE
Test out `Support scroll: false for Link component for app router #51869`

### DIFF
--- a/app/components/InfiniteScrollWrapper.tsx
+++ b/app/components/InfiniteScrollWrapper.tsx
@@ -19,9 +19,10 @@ export function InfiniteScrollWrapper({
         // Ugly, I know
         if (entry.isIntersecting) {
           router.replace(
-            `?page=${parseInt(searchParams.get("page") ?? "0") + 1}`
+            `?page=${parseInt(searchParams.get("page") ?? "0") + 1}`,
+	    {scroll: false}
           );
-          router.refresh();
+          //router.refresh();
           console.log("loading more");
         }
       },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Inter } from "@next/font/google";
+import { Inter } from "next/font/google";
 
 import "./globals.css";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { InfiniteScrollWrapper } from "./components/InfiniteScrollWrapper";
 import { Item } from "./components/Item";
 import { ItemData } from "./types";
 
-export default function Home({ searchParams }) {
+export default function Home({ searchParams }: { searchParams: { page: string }}) {
   const { page } = searchParams;
 
   const intPage = parseInt(page ?? "0");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,10 @@
 import Link from "next/link";
 import { Suspense } from "react";
-import { Code } from "./components/Code";
+// import { Code } from "./components/Code";
 import { InfiniteScrollWrapper } from "./components/InfiniteScrollWrapper";
 import { Item } from "./components/Item";
 import { ItemData } from "./types";
 
-// @ts-ignore
 export default function Home({ searchParams }) {
   const { page } = searchParams;
 
@@ -17,9 +16,9 @@ export default function Home({ searchParams }) {
         <p>
           This is a demo exploring using React 18 Server components as a
           mechanism to load more and render more data in an infinite scrolling
-          list. The project is made in Next.js 13 in the <Code>app</Code> dir.
+          list. The project is made in Next.js 13 in the app dir.
         </p>
-        <p>
+        {/* <p>
           It works by using query params. By default, one &quot;page&quot; is
           loaded. As you scorll down, a client component containing an
           IntersectionOvserver is triggered, which adds <Code>1</Code> to the
@@ -39,7 +38,7 @@ export default function Home({ searchParams }) {
             Edge Runtime
           </Link>{" "}
           on Vercel to render, which has no cold boot time.
-        </p>
+        </p> */}
       </header>
       <ul className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <InfiniteScrollWrapper>

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
-    scrollRestoration: true,
-    runtime: "experimental-edge",
-  },
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@next/font": "13.4.7",
     "@types/node": "18.16.19",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "18.2.6",
     "eslint": "8.44.0",
     "eslint-config-next": "13.4.7",
-    "next": "13.4.7",
+    "next": "^13.4.9-canary.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,11 +119,6 @@
   dependencies:
     glob "7.1.7"
 
-"@next/font@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.4.7.tgz#32f9e2c4a856e23370d2be4b46eddaccce11b88d"
-  integrity sha512-l28ifb3pjKznQeXmiCD5VXkmqdpMrcUQMr4ZChAgTKrjckl/aGyRLOIlL/ABhTHmzMujdt/TTWUsdABArNK5gA==
-
 "@next/swc-darwin-arm64@13.4.9-canary.1":
   version "13.4.9-canary.1"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.9-canary.1.tgz#9af5abc62645a38e6b5ae98a173603c6dfa02ab3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,10 +107,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@next/env@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.7.tgz#ca12d341edb128ca70384635bd2794125ffb1c01"
-  integrity sha512-ZlbiFulnwiFsW9UV1ku1OvX/oyIPLtMk9p/nnvDSwI0s7vSoZdRtxXNsaO+ZXrLv/pMbXVGq4lL8TbY9iuGmVw==
+"@next/env@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.9-canary.1.tgz#603ecc94fcb0f74b8e16af5f5b6c911a47d7b303"
+  integrity sha512-sXC2sJx2eG3essLnmo3TZqrHC/iNJuOjQ7PaejBrfaNzWRQGM0LlYOrByzL/7ukhPItjiTOjC+rSi5SoHK+ITA==
 
 "@next/eslint-plugin-next@13.4.7":
   version "13.4.7"
@@ -124,50 +124,50 @@
   resolved "https://registry.yarnpkg.com/@next/font/-/font-13.4.7.tgz#32f9e2c4a856e23370d2be4b46eddaccce11b88d"
   integrity sha512-l28ifb3pjKznQeXmiCD5VXkmqdpMrcUQMr4ZChAgTKrjckl/aGyRLOIlL/ABhTHmzMujdt/TTWUsdABArNK5gA==
 
-"@next/swc-darwin-arm64@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.7.tgz#5e36c26dda5b0bc0ea15d8555d0abd71a1ef4b5d"
-  integrity sha512-VZTxPv1b59KGiv/pZHTO5Gbsdeoxcj2rU2cqJu03btMhHpn3vwzEK0gUSVC/XW96aeGO67X+cMahhwHzef24/w==
+"@next/swc-darwin-arm64@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.9-canary.1.tgz#9af5abc62645a38e6b5ae98a173603c6dfa02ab3"
+  integrity sha512-SMd4EE/512oPh5Fe9/rDdz+7tjpmV+0zCsGYIU7JElyZ9lJWm2kIo+NZlYbWwpkRdVwsWVgZ/0LI91lrTWsiUQ==
 
-"@next/swc-darwin-x64@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.7.tgz#4c14ec14b200373cd602589086cb1253a28cd803"
-  integrity sha512-gO2bw+2Ymmga+QYujjvDz9955xvYGrWofmxTq7m70b9pDPvl7aDFABJOZ2a8SRCuSNB5mXU8eTOmVVwyp/nAew==
+"@next/swc-darwin-x64@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.9-canary.1.tgz#c0360c000899d25672903a019c1ca54c895eeddc"
+  integrity sha512-QGgkepKAtbeJuCDaQYCcffYz/UDGvK4B9Qyg9hqJkRd4ZInY2fc1SWzHjCYQ1cDe9xM32+IK9JhA8p7/h6Nz+A==
 
-"@next/swc-linux-arm64-gnu@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.7.tgz#e7819167ec876ddac5a959e4c7bce4d001f0e924"
-  integrity sha512-6cqp3vf1eHxjIDhEOc7Mh/s8z1cwc/l5B6ZNkOofmZVyu1zsbEM5Hmx64s12Rd9AYgGoiCz4OJ4M/oRnkE16/Q==
+"@next/swc-linux-arm64-gnu@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.9-canary.1.tgz#8d836016c841b7c1578140cc0319f5c24acff8fe"
+  integrity sha512-HffAAHmC9WTUiR23auK/ToSXSUHf7Cv4MIzcVn/HTvWkYKBUklGcgEmqksJ3wlRhe1OmvNjei5daDZsbEgixbQ==
 
-"@next/swc-linux-arm64-musl@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.7.tgz#0cac0f01d4e308b439e6c33182bed77835fe383b"
-  integrity sha512-T1kD2FWOEy5WPidOn1si0rYmWORNch4a/NR52Ghyp4q7KyxOCuiOfZzyhVC5tsLIBDH3+cNdB5DkD9afpNDaOw==
+"@next/swc-linux-arm64-musl@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.9-canary.1.tgz#6a78a07c2bd3ffbcf7cb1c01805abf01a3520bf4"
+  integrity sha512-ihLGywdh7RMsY6DJGP022D1O8SuURmE5PvYf0+Hw/Gbb/LK6b3f788eqQm5yQf8xkvDxC7apF7mU3bPGhE6m5g==
 
-"@next/swc-linux-x64-gnu@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.7.tgz#feb61e16a68c67f3ef230f30d9562a3783c7bd59"
-  integrity sha512-zaEC+iEiAHNdhl6fuwl0H0shnTzQoAoJiDYBUze8QTntE/GNPfTYpYboxF5LRYIjBwETUatvE0T64W6SKDipvg==
+"@next/swc-linux-x64-gnu@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.9-canary.1.tgz#a50014cc8f9f6550b09a0364adeaaa01dcca0511"
+  integrity sha512-sdjgQriI9pd/Cqei00Qd/iVrzNGmxlSvdtjruxc+bJ37TPRFOBc4RLVTUSBLTK26yqYZoGp5wjczYQvXFouWxg==
 
-"@next/swc-linux-x64-musl@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.7.tgz#02179ecfa6d24a2956c2b54f7d27a050568bbf24"
-  integrity sha512-X6r12F8d8SKAtYJqLZBBMIwEqcTRvUdVm+xIq+l6pJqlgT2tNsLLf2i5Cl88xSsIytBICGsCNNHd+siD2fbWBA==
+"@next/swc-linux-x64-musl@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.9-canary.1.tgz#f52ab3801a5917a5b3a06c481ac5ac2b18b589e9"
+  integrity sha512-eevPj4/5y/4KNwdzIl6BxDhleA9Y4RCu9kson3Kp/1CgI0aBZ2F1mhO6huKDp9u9Esb4wr5iLBWjx+SpETP3SA==
 
-"@next/swc-win32-arm64-msvc@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.7.tgz#274b7f00a2ec5934af73db15da8459e8647bfaed"
-  integrity sha512-NPnmnV+vEIxnu6SUvjnuaWRglZzw4ox5n/MQTxeUhb5iwVWFedolPFebMNwgrWu4AELwvTdGtWjqof53AiWHcw==
+"@next/swc-win32-arm64-msvc@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.9-canary.1.tgz#5a2940ae0a9a8a52446554f21803dc0776062891"
+  integrity sha512-dpB466PXoYemixH2oNxpQ/zZXw04IoYbmMuQ9nhYst0bLOOEdtLM+ok8xfeLVlBa4O5aOh0GFJyv3bGltXqLCA==
 
-"@next/swc-win32-ia32-msvc@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.7.tgz#4a95c106a6db2eee3a4c1352b77995e298d7446a"
-  integrity sha512-6Hxijm6/a8XqLQpOOf/XuwWRhcuc/g4rBB2oxjgCMuV9Xlr2bLs5+lXyh8w9YbAUMYR3iC9mgOlXbHa79elmXw==
+"@next/swc-win32-ia32-msvc@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.9-canary.1.tgz#b764a88b4a61294aa6329948b66d7bc4939d73d6"
+  integrity sha512-AOvS+wHfKrYdfJIjuEaI+o//auXJxbU6LEFr3f/nOKXWMAWqMjw43objMoMVc+tRM2H+pJrvi0s0cCHaEFF6Dg==
 
-"@next/swc-win32-x64-msvc@13.4.7":
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.7.tgz#5137780f58d7f0230adc293a0429821bfa7d8c21"
-  integrity sha512-sW9Yt36Db1nXJL+mTr2Wo0y+VkPWeYhygvcHj1FF0srVtV+VoDjxleKtny21QHaG05zdeZnw2fCtf2+dEqgwqA==
+"@next/swc-win32-x64-msvc@13.4.9-canary.1":
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.9-canary.1.tgz#2957274aeba4e69670310ba4aaed8a0c23485538"
+  integrity sha512-yjiZS52XfTSVS+tVr+Zx+eVQGL5adsqD4X6j7MVWt/wFLLsTcCr7ew820mA2Ogviu9yIo8Wg+cd2Ln4VyQF0Aw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1696,12 +1696,12 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next@13.4.7:
-  version "13.4.7"
-  resolved "https://registry.yarnpkg.com/next/-/next-13.4.7.tgz#2ab20e6fada2e25cb81bd17f68956705ffd9824e"
-  integrity sha512-M8z3k9VmG51SRT6v5uDKdJXcAqLzP3C+vaKfLIAM0Mhx1um1G7MDnO63+m52qPdZfrTFzMZNzfsgvm3ghuVHIQ==
+next@^13.4.9-canary.1:
+  version "13.4.9-canary.1"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.4.9-canary.1.tgz#9e064737de343fb3baf3229c17145a52dfe58f74"
+  integrity sha512-mGk7mu7+mdYd3DvDrJZ+lnwFIkJs/1/uHBYp5TKScb3rmme8SVUtvms45vzh0KHR0ugkvKtV6fDTmriaqsi1LQ==
   dependencies:
-    "@next/env" "13.4.7"
+    "@next/env" "13.4.9-canary.1"
     "@swc/helpers" "0.5.1"
     busboy "1.6.0"
     caniuse-lite "^1.0.30001406"
@@ -1710,15 +1710,15 @@ next@13.4.7:
     watchpack "2.4.0"
     zod "3.21.4"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "13.4.7"
-    "@next/swc-darwin-x64" "13.4.7"
-    "@next/swc-linux-arm64-gnu" "13.4.7"
-    "@next/swc-linux-arm64-musl" "13.4.7"
-    "@next/swc-linux-x64-gnu" "13.4.7"
-    "@next/swc-linux-x64-musl" "13.4.7"
-    "@next/swc-win32-arm64-msvc" "13.4.7"
-    "@next/swc-win32-ia32-msvc" "13.4.7"
-    "@next/swc-win32-x64-msvc" "13.4.7"
+    "@next/swc-darwin-arm64" "13.4.9-canary.1"
+    "@next/swc-darwin-x64" "13.4.9-canary.1"
+    "@next/swc-linux-arm64-gnu" "13.4.9-canary.1"
+    "@next/swc-linux-arm64-musl" "13.4.9-canary.1"
+    "@next/swc-linux-x64-gnu" "13.4.9-canary.1"
+    "@next/swc-linux-x64-musl" "13.4.9-canary.1"
+    "@next/swc-win32-arm64-msvc" "13.4.9-canary.1"
+    "@next/swc-win32-ia32-msvc" "13.4.9-canary.1"
+    "@next/swc-win32-x64-msvc" "13.4.9-canary.1"
 
 node-releases@^2.0.12:
   version "2.0.12"


### PR DESCRIPTION
I continue to find this repo to be a helpful tool in evaluating NextJS features/fixes. Recently, https://github.com/vercel/next.js/pull/51869 landed in `canary`, which adds support for `scroll={false}` in the app router. I was curious whether that was enough to get this demo working, and it seems like it is (no longer getting scroll position reset to the top of the page, browser back button is returning to the correct spot in the feed). I figured I would share the code in case you or anyone else was curious.

- [x] Upgrade to `13.4.9-canary.1`
- [x] Do some light cleanups (migrate to `next/font` and remove unused `experimental` config entries)
- [x] Use `router.replace(href, {scroll: false}` and remove the `router.replace` (not sure if we still need this for anything)
- [x] Comment out the the use of the `Code` component as this was causing hydration errors that I didn't know how to fix.

Of course, these changes still don't address the performance issue you noted earlier  (that each page is re-fetching all prior pages). I guess we are waiting on a new RSC primitive to help with that.